### PR TITLE
Mapper MovimientoDomain ↔ MovimientoORM

### DIFF
--- a/backend/app/db/models/movimiento.py
+++ b/backend/app/db/models/movimiento.py
@@ -1,0 +1,34 @@
+# module: backend/app/db/models/movimiento.py
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Enum, CheckConstraint, text
+from sqlalchemy.orm import relationship
+from backend.app.domain.models.movimiento import TipoMovimiento
+from backend.app.db.base import EntityBase
+
+class MovimientoORM(EntityBase):
+    __tablename__ = "movimientos"
+    __table_args__ = (
+        CheckConstraint('cantidad >= 0', name='ck_movimientos_cantidad_non_negative'),
+    )
+    # Columnas de la tabla
+    producto_id = Column(Integer, ForeignKey("productos.id"), nullable=False, index=True)
+    deposito_origen_id = Column(Integer, ForeignKey("depositos.id"), nullable=True, index=True)
+    deposito_destino_id = Column(Integer, ForeignKey("depositos.id"), nullable=True, index=True)
+    usuario_id = Column(Integer, ForeignKey("usuarios.id"), nullable=False, index=True)
+    cantidad = Column(Integer, nullable=False)
+    # Fecha la asigna la base de datos para evitar desincronías de horario
+    fecha = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=False)
+    tipo = Column(Enum(TipoMovimiento, native_enum=False), nullable=False)  # como string en BD
+
+    # Relaciones
+    producto = relationship("ProductoORM", back_populates="movimientos")
+    deposito_origen = relationship("DepositoORM",foreign_keys=[deposito_origen_id],back_populates="movimientos_origen")
+    deposito_destino = relationship("DepositoORM",foreign_keys=[deposito_destino_id],back_populates="movimientos_destino")
+    usuario = relationship("UsuarioORM")
+
+    # Representación para debugging
+    def __repr__(self):
+        return (
+            f"<MovimientoORM(id={self.id}, producto_id={self.producto_id}, "
+            f"deposito_origen_id={self.deposito_origen_id}, deposito_destino_id={self.deposito_destino_id}, "
+            f"usuario_id={self.usuario_id}, cantidad={self.cantidad}, fecha={self.fecha}, tipo={self.tipo})>"
+        )

--- a/backend/app/db/models/movimiento.py
+++ b/backend/app/db/models/movimiento.py
@@ -2,9 +2,9 @@
 from sqlalchemy import Column, Integer, ForeignKey, DateTime, Enum, CheckConstraint, text
 from sqlalchemy.orm import relationship
 from backend.app.domain.models.movimiento import TipoMovimiento
-from backend.app.db.base import EntityBase
+from backend.app.db.base import base # clase de la base de dato de SQLAlchemy
 
-class MovimientoORM(EntityBase):
+class MovimientoORM(base):
     __tablename__ = "movimientos"
     __table_args__ = (
         CheckConstraint('cantidad >= 0', name='ck_movimientos_cantidad_non_negative'),

--- a/backend/app/db/models/producto.py
+++ b/backend/app/db/models/producto.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
 from backend.app.db.base import base # clase de la base de dato de SQLAlchemy
 
 class ProductoORM(base):
@@ -10,3 +11,5 @@ class ProductoORM(base):
     categoria = Column(String)
     descripcion = Column(String)
     unidad_medida = Column(String)
+
+movimientos = relationship("MovimientoORM", back_populates="producto")

--- a/backend/app/domain/models/movimiento.py
+++ b/backend/app/domain/models/movimiento.py
@@ -1,16 +1,24 @@
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
+from typing import Optional
 from .producto import Producto
 from .deposito import Deposito
 from .usuario import Usuario
-
+class TipoMovimiento(str, Enum):
+    INGRESO = "ingreso"
+    EGRESO = "egreso"
+    TRASLADO = "traslado"
 @dataclass
 class Movimiento:
-    id: int
-    producto: Producto                  # referencia al producto
-    deposito_origen: Deposito           # depósito de origen
-    deposito_destino: Deposito          # depósito de destino
-    usuario: Usuario                    # usuario que realiza el movimiento
+    id: Optional[int]
+    producto: Producto # referencia al producto
+    deposito_origen: Optional[Deposito]  # depósito de origen, opcional porque un ingreso solo requiere depósito destino
+    deposito_destino: Optional[Deposito] # depósito de destino, opcional porque un egreso solo requiere depósito origen
+    usuario: Usuario   # usuario que realiza el movimiento
     cantidad: int
     fecha: datetime
-    tipo: str  # 'ingreso', 'egreso', 'traslado'
+    tipo: TipoMovimiento
+
+
+

--- a/backend/app/mappers/movimiento_mapper.py
+++ b/backend/app/mappers/movimiento_mapper.py
@@ -1,0 +1,40 @@
+from typing import Optional
+from backend.app.domain.models.movimiento import Movimiento, TipoMovimiento
+from backend.app.domain.models.producto import Producto
+from backend.app.domain.models.deposito import Deposito
+from backend.app.domain.models.usuario import Usuario
+from backend.app.db.models.movimiento import MovimientoORM
+
+#Convierte un MovimientoORM a Movimiento del dominio
+def movimiento_orm_to_domain(
+    orm: MovimientoORM,
+    producto: Producto,
+    usuario: Usuario,
+    deposito_origen: Optional[Deposito] = None,
+    deposito_destino: Optional[Deposito] = None
+) -> Movimiento:
+    return Movimiento(
+        id=orm.id,
+        producto=producto,
+        deposito_origen=deposito_origen,
+        deposito_destino=deposito_destino,
+        usuario=usuario,
+        cantidad=orm.cantidad,
+        fecha=orm.fecha,
+        tipo=TipoMovimiento(orm.tipo)
+    )
+
+#Convierte un Movimiento del dominio a MovimientoORM listo para persistencia
+def movimiento_domain_to_orm(domain: Movimiento) -> MovimientoORM:
+    orm = MovimientoORM(
+        producto_id=domain.producto.id,
+        deposito_origen_id=domain.deposito_origen.id if domain.deposito_origen else None,
+        deposito_destino_id=domain.deposito_destino.id if domain.deposito_destino else None,
+        usuario_id=domain.usuario.id,
+        cantidad=domain.cantidad,
+        fecha=domain.fecha,
+        tipo=domain.tipo.value
+    )
+    if domain.id is not None:
+        orm.id = domain.id
+    return orm


### PR DESCRIPTION
### Descripción
Este PR implementa los **mapeadores** entre el modelo de dominio `Movimiento` y el modelo ORM `MovimientoORM`.  
Permite convertir objetos del ORM a objetos de dominio y viceversa, respetando las relaciones con `Producto`, `Deposito` y `Usuario`.

### Cambios principales
- Se agrega `MovimientoORM` en `backend/app/db/models/movimiento.py`.
- Se agrega la clase de dominio `Movimiento` en `backend/app/domain/models/movimiento.py`.
- Se agregan los `mappers` entre ORM y dominio en `backend/app/mappers/movimiento_mapper.py`.
- Se modifica `ProductoORM` en `backend/app/db/models/producto.py`.

### Issue relacionado
Closes #27
