### PR TITLE
docs + tests: reglas de negocio para MovimientoRepository y tests iniciales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,8 @@ migrations/__pycache__/
 
 # Archivos del sistema
 .DS_Store
-Thumbs.db
+Thumbs.db.venv/
+backend.db
+.env
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ backend.db
 .env
 __pycache__/
 *.pyc
+.venv/
+backend.db
+.env
+__pycache__/
+*:pyc

--- a/backend/tests/tests_movimiento_repository.py
+++ b/backend/tests/tests_movimiento_repository.py
@@ -1,0 +1,38 @@
+
+
+
+
+import pytest
+from datetime import datetime
+from backend.repositories.movimiento_repository import MovimientoRepository
+
+
+@pytest.fixture
+def fake_db_session():
+    
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind = engine)
+    
+    yield Session()
+
+@pytest.fixture
+def test_crear_movimiento_valido(fake_db_session):
+    repo = MovimientoRepository(Session = fake_db_session)
+    movimiento_data = {
+        "producto_id": 1,
+        "cantidad": 10,
+        "tipo": "entrada"
+        }
+    movimiento = repo.crear_movimiento(movimiento_data)
+    assert movimiento.id is not None
+    assert movimiento.cantidad == 10
+    assert movimiento.tipo == "entrada"
+    assert hasattr(movimiento, fecha_creacion)
+    
+def test_crear_movimiento_salida_sin_stock(fake_db_session):
+    repo = MovimientoRepository(Session = fake_db_session)
+    
+    with pytest.raises(ValueError):
+        repo.crear_movimiento(producto_id = 2, cantidad = 5, tipo = "salida")

--- a/docs/semana-04/reglas_negocio_movimiento.md
+++ b/docs/semana-04/reglas_negocio_movimiento.md
@@ -1,0 +1,14 @@
+Reglas de negocio para MovimientoRepository
+
+1. Crear movimiento:
+   - 'cantidad' debe ser > 0
+   - 'tipo' puede ser 'entrada' o 'salida'
+   - Si es 'salida', verificar que el stock sea suficiente
+   - Guardar fecha/hora UTC de creación
+
+2. Actualizar movimiento:
+   - No se puede cambiar producto_id
+   - Si se modifica cantidad, actualizar stock y registro de auditoría
+
+3. Eliminar movimiento:
+   - Solo eliminación lógica (activo = False)


### PR DESCRIPTION
## Resumen
Agrego la documentación de reglas de negocio para `MovimientoRepository` y una suite de pruebas unitarias inicial (plantilla).

## Cambios incluidos
- `docs/semana-04/reglas_negocio_movimiento.md` — reglas de negocio (crear/actualizar/eliminar).
- `backend/tests/tests_movimiento_repository.py` — tests iniciales (plantilla).

## Cómo probar localmente
1. Activar entorno virtual:
   Windows (PowerShell): `.venv\Scripts\activate`
2. Instalar dependencias mínimas:
   `pip install pytest sqlalchemy`
3. Ejecutar tests (opcional):
   `python -m pytest backend/tests/tests_movimiento_repository.py -q`

## Issues relacionados
Closes ignacio-leonel/is2-2025-grupo7#25
Closes ignacio-leonel/is2-2025-grupo7#24

## Notas
- Excluí `.venv/` y `backend.db` en `.gitignore`.
- Si requieren que adapte los tests a la DB real o que cree fixtures para los modelos, lo agrego en un PR siguiente.

**Checklist**
- [ ] Documentación revisada
- [ ] Tests añadidos
- [ ] PR listo para revisión
